### PR TITLE
Updated Package.swift to support both Swift 5 and Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,6 @@ let package = Package(
         )
     ],
     swiftLanguageVersions: [
-        .version("6")
+        .version("6"), .v5
     ]
 )


### PR DESCRIPTION
Added `.v5` to swiftLanguageVersions array alongside existing `.version("6")`
Verified package builds successfully with Swift 5 & 6