### PR TITLE
Make NavigationDestination Conform to Codable

### DIFF
--- a/NavigatorDemo/NavigatorDemo/NavigatorDemo/Features/Accounts/Accounts.swift
+++ b/NavigatorDemo/NavigatorDemo/NavigatorDemo/Features/Accounts/Accounts.swift
@@ -69,4 +69,4 @@ struct AccountDisclaimersView: View {
     }
 }
 
-struct Account: Hashable {}
+struct Account: Hashable, Codable {}

--- a/NavigatorDemo/NavigatorDemo/NavigatorDemo/Features/Home/HomeDestinations.swift
+++ b/NavigatorDemo/NavigatorDemo/NavigatorDemo/Features/Home/HomeDestinations.swift
@@ -8,7 +8,7 @@
 import Navigator
 import SwiftUI
 
-public enum HomeDestinations: Codable {
+public enum HomeDestinations {
     case home(String)
     case page2
     case page3

--- a/NavigatorDemo/NavigatorDemo/NavigatorDemo/Features/Settings/SettingsDestinations.swift
+++ b/NavigatorDemo/NavigatorDemo/NavigatorDemo/Features/Settings/SettingsDestinations.swift
@@ -8,7 +8,7 @@
 import Navigator
 import SwiftUI
 
-public enum SettingsDestinations: Int, Codable {
+public enum SettingsDestinations: Int {
     case page2
     case page3
     case sheet

--- a/Sources/Navigator/Navigator/Core/NavigationDestination.swift
+++ b/Sources/Navigator/Navigator/Core/NavigationDestination.swift
@@ -92,7 +92,7 @@ import SwiftUI
 ///
 /// > Important: When using `NavigationLink(value:label:)` the method will be ignored and SwiftUI will push
 /// the value onto the navigation stack as it would normally.
-public protocol NavigationDestination: Codable, Hashable, Equatable, Identifiable {
+public protocol NavigationDestination: Codable, Hashable, Identifiable {
 
     associatedtype Content: View
 

--- a/Sources/Navigator/Navigator/Core/NavigationDestination.swift
+++ b/Sources/Navigator/Navigator/Core/NavigationDestination.swift
@@ -92,7 +92,7 @@ import SwiftUI
 ///
 /// > Important: When using `NavigationLink(value:label:)` the method will be ignored and SwiftUI will push
 /// the value onto the navigation stack as it would normally.
-public protocol NavigationDestination: Hashable, Equatable, Identifiable {
+public protocol NavigationDestination: Codable, Hashable, Equatable, Identifiable {
 
     associatedtype Content: View
 


### PR DESCRIPTION
Fixes #15 - Currently, the `NavigationDestination` enum does not conform to `Codable`, and it is not enforced. Users need to ensure their cases conform to `Codable`. This also eliminates Xcode runtime errors in the console logs. 

I’ve also removed `Equatable` as `Hashable` already includes it.