### PR TITLE
Fix typo in documentation code snippet

### DIFF
--- a/Sources/Navigator/Documentation.docc/Basics/Checkpoints.md
+++ b/Sources/Navigator/Documentation.docc/Basics/Checkpoints.md
@@ -39,7 +39,7 @@ struct RootHomeView: View {
     var body: some View {
         ManagedNavigationStack(scene: "home") {
             HomeContentView(title: "Home Navigation")
-                .navigationCheckpoint(KnownCheckpoints..home)
+                .navigationCheckpoint(KnownCheckpoints.home)
                 .navigationDestination(HomeDestinations.self)
         }
     }


### PR DESCRIPTION
Fixed a minor typo in the code snippet (`KnownCheckpoints..home` → `KnownCheckpoints.home`).