### PR TITLE
docs: fix documentation url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,5 +370,5 @@ Michael was also one of Google's [Open Source Peer Reward](https://opensource.go
 * [Medium: Navigation Checkpoints in SwiftUI](https://michaellong.medium.com/navigation-checkpoints-in-swiftui-345270388240?sk=a7802f5351fcb3b5cfced714d0bcfaec)
 * [Medium: SwiftUI Navigation With Dismissible](https://michaellong.medium.com/swiftui-navigation-with-dismissible-8de3cab72a4e?sk=dcb743fbb90d59c5775fed33725958b9)
 * [Medium: Now Previewing Navigator!](https://michaellong.medium.com/now-previewing-navigator-faebf290a1da?sk=88d3ff52057cf0a948279e6be4a15f75)
-* [Navigator Documentation](https://hmlongco.github.io/Navigator/documentation/navigator)
+* [Navigator Documentation](https://hmlongco.github.io/Navigator/documentation/navigatorui)
 * [Factory](https://hmlongco.github.io/Factory/)


### PR DESCRIPTION
Thanks so much for your work on this! I wanted to check out the documentation and realized the link in the README was broken. I thought it's because of adding the ui postfix to the name and turns out it was!

Again, thanks so much for creating this project it seems to provide exactly what I was looking for to bring sanity to the SwiftUI navigation in my app!