### PR TITLE
Fix typo and method name casing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Button("Button Push Home Page 55") {
     navigator.push(HomeDestinations.pageN(55))
 }
 ```
-In case you're wondering, calling `push` pushes the associate view onto the current `NavigationStack`, while `Navigate(to:)` will push
+In case you're wondering, calling `push` pushes the associated view onto the current `NavigationStack`, while `navigate(to:)` will push
 the view or present the view, based on the `NavigationMethod` specified (coming up next).
 
 ### Navigation Methods


### PR DESCRIPTION
- Fixed 'associate view' → 'associated view'
- Updated 'Navigate(to:)' → 'navigate(to:)' to match Swift naming conventions

Hi Michael,

I've always enjoyed reading your articles on Medium - they've given me a lot of insight and inspiration.

Thank you for creating and maintaining such a great library. While reading the README to try it out, I noticed a couple of small improvements and decided to open my very first pull request to an open source project.

I really appreciate your work!