### PR TITLE
Fixed an example in the Deep Linking Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ struct RootHomeView: View {
         ManagedNavigationStack(scene: "home") {
             HomeContentView(title: "Home Navigation")
                 .navigationDestination(HomeDestinations.self)
-                .onNavigationReceive(HomeDestinations.self) // shortcut
+                .navigationAutoReceive(HomeDestinations.self) // shortcut
         }
     }
 }


### PR DESCRIPTION
The section "[Deep Linking Support](https://github.com/hmlongco/Navigator?tab=readme-ov-file#deep-linking-support)" in the readme mentions the following example:

```
struct RootHomeView: View {
    var body: some View {
        ManagedNavigationStack(scene: "home") {
            HomeContentView(title: "Home Navigation")
                .navigationDestination(HomeDestinations.self)
                .onNavigationReceive(HomeDestinations.self) // shortcut
        }
    }
}
```

But it seems this is incorrect because the compiler will complain about the parameter for `onNavigationReceive`. It seems the correct method to use is `navigationAutoReceive`. Therefore, fixed the readme accordingly.
