### PR TITLE
Use .fullScreenCover for NavigationMethod.cover on all platforms

### DIFF
--- a/Sources/NavigatorUI/NavigatorUI/Core/NavigationOperations.swift
+++ b/Sources/NavigatorUI/NavigatorUI/Core/NavigationOperations.swift
@@ -47,11 +47,7 @@ extension Navigator {
         case .cover, .managedCover:
             guard state.cover?.id != destination.id else { return }
             log(.navigation(.presenting(destination.wrapped)))
-            #if os(iOS)
             state.cover = destination
-            #else
-            state.sheet = destination
-            #endif
         }
     }
 

--- a/Sources/NavigatorUI/NavigatorUI/Core/NavigationPresentation.swift
+++ b/Sources/NavigatorUI/NavigatorUI/Core/NavigationPresentation.swift
@@ -120,11 +120,9 @@ internal struct NavigationPresentationModifiers: ViewModifier {
             .sheet(item: $state.sheet) { (destination) in
                 managedView(for: destination)
             }
-            #if os(iOS)
             .fullScreenCover(item: $state.cover) { (destination) in
                 managedView(for: destination)
             }
-            #endif
     }
 
     @ViewBuilder func managedView(for destination: AnyNavigationDestination) -> some View {


### PR DESCRIPTION
Resolves #78

It's a breaking change for anyone using Navigator on platforms other than iOS and expecting `.sheet` presentation for `NavigationMethod.cover` or `.managedCover`.