### PR TITLE
Add navigator name for logging and ManagedPresentationView

### DIFF
--- a/Sources/NavigatorUI/NavigatorUI/Core/NavigationEventLogging.swift
+++ b/Sources/NavigatorUI/NavigatorUI/Core/NavigationEventLogging.swift
@@ -31,7 +31,7 @@ extension Navigator {
         guard verbosity.rawValue >= configuration.verbosity.rawValue else {
             return
         }
-        logger(.init(verbosity: .info, navigator: id, event: event, timestamp: Date()))
+        logger(.init(verbosity: .info, navigator: id, navigatorName: name, event: event, timestamp: Date()))
     }
 }
 
@@ -44,12 +44,17 @@ nonisolated public struct NavigationEvent: CustomStringConvertible {
 
     let verbosity: Verbosity
     let navigator: UUID
+    let navigatorName: String?
     let event: Event
     let timestamp: Date
 
     /// A human-readable description suitable for logging.
     public var description: String {
-        "Navigator \(navigator) \(event)"
+        if let navigatorName {
+            "Navigator \(navigator) (\(navigatorName)) \(event)"
+        } else {
+            "Navigator \(navigator) \(event)"
+        }
     }
 
 }
@@ -103,12 +108,32 @@ extension NavigationEvent {
         }
 
         /// Lifecycle events for a given navigator instance.
-        nonisolated public enum LifecycleEvent {
+        nonisolated public enum LifecycleEvent: CustomStringConvertible {
             case configured
             case intialized
-            case adding(UUID)
-            case removing(UUID)
+            case adding(UUID, name: String?)
+            case removing(UUID, name: String?)
             case `deinit`
+
+            nonisolated public var description: String {
+                switch self {
+                case .configured: "configured"
+                case .intialized: "intialized"
+                case .adding(let id, let name):
+                    if let name {
+                        "adding \(id) (\(name))"
+                    } else {
+                        "adding \(id)"
+                    }
+                case .removing(let id, let name):
+                    if let name {
+                        "removing \(id) (\(name))"
+                    } else {
+                        "removing \(id)"
+                    }
+                case .deinit: "deinit"
+                }
+            }
         }
 
         /// Events related to presenting and popping navigation destinations.

--- a/Sources/NavigatorUI/NavigatorUI/Core/NavigationPresentation.swift
+++ b/Sources/NavigatorUI/NavigatorUI/Core/NavigationPresentation.swift
@@ -85,8 +85,8 @@ extension View {
     /// }
     /// ```
     /// > Warning: Failure to tag presented views as such can lead to inconsistent deep linking and navigation behavior.
-    public func managedPresentationView() -> some View {
-        ManagedPresentationView {
+    public func managedPresentationView(name: String? = nil) -> some View {
+        ManagedPresentationView(name: name) {
             self
         }
     }

--- a/Sources/NavigatorUI/NavigatorUI/Core/Navigator.swift
+++ b/Sources/NavigatorUI/NavigatorUI/Core/Navigator.swift
@@ -227,12 +227,12 @@ public final class Navigator: @unchecked Sendable {
         child.navigationModifierInherits = navigationModifierInherits
         child.presentationModifier = presentationModifierInherits ? presentationModifier : nil
         child.presentationModifierInherits = presentationModifierInherits
-        log(.lifecycle(.adding(child.id)))
+        log(.lifecycle(.adding(child.id, name: child.name)))
     }
 
     /// Removes a child navigator from a parent.
     internal func removeChild(_ child: Navigator) {
-        log(.lifecycle(.removing(child.id)))
+        log(.lifecycle(.removing(child.id, name: child.name)))
         _children.removeValue(forKey: child.id)
         if child.isPresented {
             self.isPresenting = false

--- a/Sources/NavigatorUI/NavigatorUI/Views/ManagedPresentationView.swift
+++ b/Sources/NavigatorUI/NavigatorUI/Views/ManagedPresentationView.swift
@@ -56,9 +56,9 @@ public struct ManagedPresentationView<Content: View>: View {
     ///     }
     /// }
     /// ```
-    public init(@ViewBuilder content: () -> Content) {
+    public init(name: String? = nil, @ViewBuilder content: () -> Content) {
         self.content = content()
-        self._navigator = .init(wrappedValue: Navigator(owner: .presenter, name: nil))
+        self._navigator = .init(wrappedValue: Navigator(owner: .presenter, name: name))
     }
 
     /// The view content configured with a dedicated `Navigator` and


### PR DESCRIPTION
Hello! I've been using your library quite a lot and I greatly appreciate it (together with Factory!). I've opened this PR to slightly improve the debugging experience.

This PR threads an optional `name` through `ManagedPresentationView` (and its `.managedPresentationView()` modifier) so individual presentations can be tagged for identification. It also surfaces the owning navigator's name in navigation event log messages, which makes it much easier to follow what's happening when several navigators are active at once.