### PR TITLE
feat: add CocoaPods support

### DIFF
--- a/NavigatorUI.podspec
+++ b/NavigatorUI.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name             = 'NavigatorUI'
+  s.version          = '2.0.2'
+  s.summary          = 'Advanced navigation support for SwiftUI based on NavigationStack'
+  
+  s.description      = <<-DESC
+  Navigator provides SwiftUI with a simple yet powerful navigation layer based on NavigationStack.
+  Supports deep linking, checkpoints, modular app patterns, coordination, and eliminates
+  the need for manual navigationDestination registrations.
+  DESC
+  
+  s.homepage         = 'https://github.com/hmlongco/Navigator'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = "Michael Long"
+  s.source           = { :git => 'https://github.com/hmlongco/Navigator.git', :tag => s.version.to_s }
+  
+  s.swift_version    = '5.10'
+  s.platforms        = {
+    :ios => '17.0',
+    :osx => '14.0',
+    :tvos => '17.0',
+    :watchos => '10.0',
+    :visionos => '1.0'
+  }
+  
+  s.source_files     = 'Sources/NavigatorUI/NavigatorUI/**/*.swift'
+  s.resource_bundles = { 'NavigatorUI_Privacy' => ['Sources/NavigatorUI/PrivacyInfo.xcprivacy'] }
+  s.frameworks       = 'SwiftUI', 'Combine', 'Foundation'
+  
+end

--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ Also see Additional Resources section below.
 
 ## Installation
 
+### Swift Package Manager
+
 Navigator supports the Swift Package Manager.
 
 Or download the source files and add the Navigator folder to your project.
@@ -451,6 +453,28 @@ Or download the source files and add the Navigator folder to your project.
 Then `import NavigatorUI` into your project where needed.
 
 Note that the current version of Navigator requires Swift 5.10 minimum and that the minimum version of iOS currently supported with this release is iOS 16.
+
+### CocoaPods
+
+Navigator is also available through CocoaPods. Add the following to your `Podfile`:
+
+```ruby
+pod 'NavigatorUI', '~> 2.0'
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+Import the module where needed:
+
+```swift
+import NavigatorUI
+```
+
+**Requirements:** iOS 17+, macOS 14+, tvOS 17+, watchOS 10+, visionOS 1.0, Swift 5.10+.
 
 ## Demo Applications
 


### PR DESCRIPTION
This PR adds **CocoaPods** support for Navigator by including a `.podspec` and updating installation/documentation as needed.

Changes:

- Added podspec for CocoaPods distribution
- Updated installation instructions in README
- Kept existing Swift Package Manager support intact